### PR TITLE
Make some utils as public

### DIFF
--- a/src/main/java/com/anthonynsimon/url/PathResolver.java
+++ b/src/main/java/com/anthonynsimon/url/PathResolver.java
@@ -6,7 +6,7 @@ import java.util.List;
 /**
  * PathResolver is a utility class that resolves a reference path against a base path.
  */
-final class PathResolver {
+public final class PathResolver {
 
     /**
      * Disallow instantiation of class.

--- a/src/main/java/com/anthonynsimon/url/PercentEncoder.java
+++ b/src/main/java/com/anthonynsimon/url/PercentEncoder.java
@@ -11,7 +11,7 @@ import java.nio.charset.StandardCharsets;
  * <p>
  * Supports UTF-8 escaping and unescaping.
  */
-final class PercentEncoder {
+public final class PercentEncoder {
 
     /**
      * Reserved characters, allowed in certain parts of the URL. Must be escaped in most cases.

--- a/src/main/java/com/anthonynsimon/url/URLParser.java
+++ b/src/main/java/com/anthonynsimon/url/URLParser.java
@@ -5,7 +5,7 @@ import com.anthonynsimon.url.exceptions.MalformedURLException;
 /**
  * URLParser handles the parsing of a URL string into a URL object.
  */
-interface URLParser {
+public interface URLParser {
     /**
      * Returns a the URL with the new values after parsing the provided URL string.
      */

--- a/src/main/java/com/anthonynsimon/url/URLPart.java
+++ b/src/main/java/com/anthonynsimon/url/URLPart.java
@@ -3,7 +3,7 @@ package com.anthonynsimon.url;
 /**
  * URLPart is used to distinguish between the parts of the url when encoding/decoding.
  */
-enum URLPart {
+public enum URLPart {
     CREDENTIALS,
     HOST,
     PATH,


### PR DESCRIPTION
Hi. I use your library as part of my library, which normalizes the url. It would be useful if some utilities from your library would be public. For example, the decoder/encoder percent-encoded string for query field. I had to copy them as separate files to access them.